### PR TITLE
add include-d-ts option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For more info, run any command with the `--help` flag:
 Options:
   --project <file>         Path to your tsconfig.json
   --skip <regexp_pattern>  Specify the regexp pattern to match files that should be skipped from transforming
+  --include-d-ts           Include .d.ts files in target for transformation
   -h, --help               Display this message
   -v, --version            Display version number
 
@@ -45,6 +46,8 @@ When you add a comment `// ts-remove-unused-skip` to your export declaration, th
 // ts-remove-unused-skip
 export const hello = 'world';
 ```
+
+By default, .d.ts files are skipped. If you want to include .d.ts files, use the --include-d-ts option.
 
 ## Known Issue
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,15 +12,20 @@ cli
     '--skip <regexp_pattern>',
     'Specify the regexp pattern to match files that should be skipped from transforming',
   )
+  .option('--include-d-ts', 'Include .d.ts files in target for transformation')
   .action((options) => {
+    const skip =
+      options.skip && Array.isArray(options.skip)
+        ? options.skip
+        : typeof options.skip === 'string'
+        ? [options.skip]
+        : [];
+    if (!options['includeD-ts']) {
+      skip.push('\\.d\\.ts');
+    }
     execute({
       tsConfigFilePath: options.project || './tsconfig.json',
-      skip:
-        options.skip && Array.isArray(options.skip)
-          ? options.skip
-          : typeof options.skip === 'string'
-          ? [options.skip]
-          : [],
+      skip,
     });
   });
 


### PR DESCRIPTION
.d.ts は基本的に export するものがないため消されやすいです。そのため `--skip '\.d\.ts'` を指定することが多いはずです。

そこでデフォルトで .d.ts を ignore して、代わりに `--include-d-ts` フラグを追加しました。