### PR TITLE
bugfix: remove export keyword for locally used declaration

### DIFF
--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -614,6 +614,33 @@ export { remain };`,
     });
   });
 
+  describe('locally used declaration but not used in any other file', () => {
+    it('should remove export keyword if its not used in any other file', () => {
+      const { languageService, fileService } = setup();
+      fileService.set('/app/main.ts', `import { a } from './a';`);
+
+      fileService.set(
+        '/app/a.ts',
+        `export const a = 'a';
+export const b = 'b';
+console.log(b);`,
+      );
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: '/app/a.ts',
+      });
+
+      assert.equal(
+        fileService.get('/app/a.ts').trim(),
+        `export const a = 'a';
+const b = 'b';
+console.log(b);`,
+      );
+    });
+  });
+
   describe('deleteUnusedFile', () => {
     it('should not remove file if some exports are used in other files', () => {
       const { languageService, fileService } = setup();

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -615,7 +615,7 @@ export { remain };`,
   });
 
   describe('locally used declaration but not used in any other file', () => {
-    it('should remove export keyword if its not used in any other file', () => {
+    it('should remove export keyword of variable if its not used in any other file', () => {
       const { languageService, fileService } = setup();
       fileService.set('/app/main.ts', `import { a } from './a';`);
 
@@ -639,6 +639,106 @@ const b = 'b';
 console.log(b);`,
       );
     });
+
+    it('should remove export keyword of class declaration if its not used in any other file', () => {
+      const { languageService, fileService } = setup();
+      fileService.set('/app/main.ts', `import { a } from './a';`);
+
+      fileService.set(
+        '/app/a.ts',
+        `export const a = 'a';
+export class B {}
+console.log(B);`,
+      );
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: '/app/a.ts',
+      });
+
+      assert.equal(
+        fileService.get('/app/a.ts').trim(),
+        `export const a = 'a';
+class B {}
+console.log(B);`,
+      );
+    });
+
+    it('should remove export keyword of interface declaration if its not used in any other file', () => {
+      const { languageService, fileService } = setup();
+      fileService.set('/app/main.ts', `import { a } from './a';`);
+
+      fileService.set(
+        '/app/a.ts',
+        `export const a = 'a';
+export interface B {}
+const b: B = {};`,
+      );
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: '/app/a.ts',
+      });
+
+      assert.equal(
+        fileService.get('/app/a.ts').trim(),
+        `export const a = 'a';
+interface B {}
+const b: B = {};`,
+      );
+    });
+  });
+
+  it('should remove export keyword of type alias declaration if its not used in any other file', () => {
+    const { languageService, fileService } = setup();
+    fileService.set('/app/main.ts', `import { a } from './a';`);
+
+    fileService.set(
+      '/app/a.ts',
+      `export const a = 'a';
+export type B = 'b';
+const b: B = 'b';`,
+    );
+
+    removeUnusedExport({
+      languageService,
+      fileService,
+      targetFile: '/app/a.ts',
+    });
+
+    assert.equal(
+      fileService.get('/app/a.ts').trim(),
+      `export const a = 'a';
+type B = 'b';
+const b: B = 'b';`,
+    );
+  });
+
+  it('should remove export keyword of interface declaration if its not used in any other file', () => {
+    const { languageService, fileService } = setup();
+    fileService.set('/app/main.ts', `import { a } from './a';`);
+
+    fileService.set(
+      '/app/a.ts',
+      `export const a = 'a';
+export interface B {}
+const b: B = {};`,
+    );
+
+    removeUnusedExport({
+      languageService,
+      fileService,
+      targetFile: '/app/a.ts',
+    });
+
+    assert.equal(
+      fileService.get('/app/a.ts').trim(),
+      `export const a = 'a';
+interface B {}
+const b: B = {};`,
+    );
   });
 
   describe('deleteUnusedFile', () => {

--- a/lib/util/removeUnusedExport.ts
+++ b/lib/util/removeUnusedExport.ts
@@ -356,19 +356,22 @@ const getTextChanges = (
 
     // we want to correctly remove 'default' when its a default export so we get the syntaxList node instead of the exportKeyword node
     // note: the first syntaxList node should contain the export keyword
-    const syntaxList = node
+    const syntaxListIndex = node
       .getChildren()
-      .find((n) => n.kind === ts.SyntaxKind.SyntaxList);
+      .findIndex((n) => n.kind === ts.SyntaxKind.SyntaxList);
 
-    if (!syntaxList) {
+    const syntaxList = node.getChildren()[syntaxListIndex];
+    const syntaxListNextSibling = node.getChildren()[syntaxListIndex + 1];
+
+    if (!syntaxList || !syntaxListNextSibling) {
       throw new Error('syntax list not found');
     }
 
     changes.push({
       newText: '',
       span: {
-        start: syntaxList.getFullStart(),
-        length: syntaxList.getFullWidth(),
+        start: syntaxList.getStart(),
+        length: syntaxListNextSibling.getStart() - syntaxList.getStart(),
       },
     });
 

--- a/lib/util/removeUnusedExport.ts
+++ b/lib/util/removeUnusedExport.ts
@@ -156,6 +156,7 @@ const isUsedFile = (
   languageService: ts.LanguageService,
   sourceFile: ts.SourceFile,
 ) => {
+  const { fileName } = sourceFile;
   let isUsed = false;
 
   const visit = (node: ts.Node) => {
@@ -173,13 +174,11 @@ const isUsedFile = (
         return;
       }
 
-      const count = references.flatMap((v) => v.references).length;
+      const count = references
+        .filter((v) => v.definition.fileName !== fileName)
+        .flatMap((v) => v.references).length;
 
-      if (ts.isExportSpecifier(node) && count > 2) {
-        // for export specifiers, there will be at least two reference, the declaration itself and the export specifier
-        isUsed = true;
-      } else if (!ts.isExportSpecifier(node) && count > 1) {
-        // there will be at least one reference, the declaration itself
+      if (count > 0) {
         isUsed = true;
       }
 
@@ -198,6 +197,7 @@ const getUnusedExports = (
   languageService: ts.LanguageService,
   sourceFile: ts.SourceFile,
 ) => {
+  const { fileName } = sourceFile;
   const result: SupportedNode[] = [];
 
   const visit = (node: ts.Node) => {
@@ -208,13 +208,11 @@ const getUnusedExports = (
         return;
       }
 
-      const count = references.flatMap((v) => v.references).length;
+      const count = references
+        .filter((v) => v.definition.fileName !== fileName)
+        .flatMap((v) => v.references).length;
 
-      if (ts.isExportSpecifier(node) && count === 2) {
-        // for export specifiers, there will be at least two reference, the declaration itself and the export specifier
-        result.push(node);
-      } else if (!ts.isExportSpecifier(node) && count === 1) {
-        // there will be at least one reference, the declaration itself
+      if (count === 0) {
         result.push(node);
       }
 


### PR DESCRIPTION
```typescript
export const a = 'a';

export const b = 'b';

export const c = 'c';

console.log(b);
```

when `c` is the only used export within the project, the expected behavior is

```typescript
const b = 'b';

export const c = 'c';

console.log(b);
```

however the current behavior is


```typescript
export const b = 'b';

export const c = 'c';

console.log(b);
```

This PR will fix this bug to remove export keywords for locally used declarations.
