### PR TITLE
fix: handle execution in non tty

### DIFF
--- a/lib/process.d.ts
+++ b/lib/process.d.ts
@@ -1,0 +1,11 @@
+declare module 'node:process' {
+  import { Socket } from 'node:net';
+
+  interface Process extends NodeJS.Process {
+    stdout: Socket | NodeJS.Process['stdout'];
+  }
+
+  const process: Process;
+
+  export = process;
+}

--- a/lib/remove.ts
+++ b/lib/remove.ts
@@ -6,12 +6,18 @@ import { Logger } from './util/Logger.js';
 import { stdout } from 'node:process';
 import { CliEditTracker } from './util/CliEditTracker.js';
 
-const createNodeJsLogger = (): Logger => ({
-  write: stdout.write.bind(stdout),
-  clearLine: stdout.clearLine.bind(stdout),
-  cursorTo: stdout.cursorTo.bind(stdout),
-  isTTY: stdout.isTTY,
-});
+const createNodeJsLogger = (): Logger =>
+  'isTTY' in stdout && stdout.isTTY
+    ? {
+        write: stdout.write.bind(stdout),
+        clearLine: stdout.clearLine.bind(stdout),
+        cursorTo: stdout.cursorTo.bind(stdout),
+        isTTY: true,
+      }
+    : {
+        write: stdout.write.bind(stdout),
+        isTTY: false,
+      };
 
 export const remove = ({
   configPath,

--- a/lib/util/Logger.ts
+++ b/lib/util/Logger.ts
@@ -1,6 +1,11 @@
-export interface Logger {
-  write(text: string): void;
-  clearLine(dir: -1 | 0 | 1): void;
-  cursorTo(x: number): void;
-  isTTY: boolean;
-}
+export type Logger =
+  | {
+      write(text: string): void;
+      clearLine(dir: -1 | 0 | 1): void;
+      cursorTo(x: number): void;
+      isTTY: true;
+    }
+  | {
+      write(text: string): void;
+      isTTY: false;
+    };


### PR DESCRIPTION
`process.stdout.clearLine` always exists under the type definition of `@types/node`. However, this method does not exist when node is executed under a non-tty environment resulting in a runtime error.

This PR patches the types and will prevent the tool from exiting with an error when it's executed in non-tty environments.