### PR TITLE
feat: remove empty lines

### DIFF
--- a/lib/util/applyCodeFix.test.ts
+++ b/lib/util/applyCodeFix.test.ts
@@ -53,7 +53,7 @@ const b = 'b';`,
       fileName: '/app/a.ts',
     });
 
-    assert.equal(result.trim(), `export const a = 'a';`);
+    assert.equal(result, `export const a = 'a';\n`);
   });
 
   it('should clean up unused imports', () => {
@@ -72,6 +72,6 @@ export const a = 'a';`,
       fileName: '/app/a.ts',
     });
 
-    assert.equal(result.trim(), `export const a = 'a';`);
+    assert.equal(result, `export const a = 'a';`);
   });
 });

--- a/lib/util/applyTextChanges.test.ts
+++ b/lib/util/applyTextChanges.test.ts
@@ -19,4 +19,28 @@ describe('applyTextChanges', () => {
 
     assert.equal(result, `export const a = 'a';\n\nexport const a3 = 'a3';\n`);
   });
+
+  it('should only allow one trailing line break at the end of the file', () => {
+    const result = applyTextChanges(
+      `\n\nconst a = 'a';\n\nexport const a2 = 'a2';\n\nconst a3 = 'a3';\n`,
+      [
+        { span: { start: 2, length: 15 }, newText: '' },
+        { span: { start: 43, length: 17 }, newText: '' },
+      ],
+    );
+    assert.equal(result.endsWith(';\n'), true);
+  });
+
+  it('should not allow a leading line break at the start of the file', () => {
+    const result = applyTextChanges(
+      `\n\nconst a = 'a';\n\nexport const a2 = 'a2';\n\nconst a3 = 'a3';\n`,
+      [
+        { span: { start: 2, length: 15 }, newText: '' },
+        { span: { start: 43, length: 17 }, newText: '' },
+      ],
+    );
+
+    console.log({ result });
+    assert.equal(result.startsWith('export const'), true);
+  });
 });

--- a/lib/util/applyTextChanges.test.ts
+++ b/lib/util/applyTextChanges.test.ts
@@ -10,4 +10,13 @@ describe('applyTextChanges', () => {
 
     assert.equal(result, `export const a = 'a';\n`);
   });
+
+  it('should remove limit the number of consecutive line breaks that occur due to the edit to 2', () => {
+    const result = applyTextChanges(
+      `export const a = 'a';\n\nconst a2 = 'a2';\n\nexport const a3 = 'a3';\n`,
+      [{ span: { start: 23, length: 17 }, newText: '' }],
+    );
+
+    assert.equal(result, `export const a = 'a';\n\nexport const a3 = 'a3';\n`);
+  });
 });

--- a/lib/util/applyTextChanges.test.ts
+++ b/lib/util/applyTextChanges.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from 'node:test';
+import { applyTextChanges } from './applyTextChanges.js';
+import assert from 'node:assert/strict';
+
+describe('applyTextChanges', () => {
+  it('should apply basic changes', () => {
+    const result = applyTextChanges(`export const a = 'a';\nconst a2 = 'a2';`, [
+      { span: { start: 22, length: 16 }, newText: '' },
+    ]);
+
+    assert.equal(result, `export const a = 'a';\n`);
+  });
+});

--- a/lib/util/applyTextChanges.ts
+++ b/lib/util/applyTextChanges.ts
@@ -51,17 +51,8 @@ export const applyTextChanges = (
     pushClean(result, remaining);
   }
 
-  const firstItem = result.shift();
-
-  if (typeof firstItem !== 'undefined') {
-    result.unshift(firstItem.replace(/^\n+/, ''));
-  }
-
-  const lastItem = result.pop();
-
-  if (typeof lastItem !== 'undefined') {
-    result.push(lastItem.replace(/\n{1,}$/, '\n'));
-  }
-
-  return result.join('');
+  return result
+    .join('')
+    .replace(/^\n+/, '')
+    .replace(/\n{1,}$/, '\n');
 };

--- a/lib/util/applyTextChanges.ts
+++ b/lib/util/applyTextChanges.ts
@@ -1,5 +1,35 @@
 import ts from 'typescript';
 
+const limitTrailingLineBreak = (value: string) => {
+  const match = value.match(/\n+$/);
+
+  if (!match) {
+    return value;
+  }
+
+  if (match[0].length <= 2) {
+    return value;
+  }
+
+  return `${value.slice(0, value.length - match[0].length)}\n\n`;
+};
+
+const pushClean = (list: string[], value: string) => {
+  const leadingLineBreakCount = value.match(/^\n+/)?.[0].length || 0;
+
+  if (leadingLineBreakCount === 0) {
+    list.push(value);
+    return;
+  }
+
+  const last = list.pop() || '';
+
+  list.push(
+    limitTrailingLineBreak(`${last}${value.slice(0, leadingLineBreakCount)}`),
+    value.slice(leadingLineBreakCount),
+  );
+};
+
 export const applyTextChanges = (
   oldContent: string,
   changes: readonly ts.TextChange[],
@@ -13,13 +43,16 @@ export const applyTextChanges = (
   let currentPos = 0;
 
   for (const change of sortedChanges) {
-    result.push(oldContent.slice(currentPos, change.span.start));
-    result.push(change.newText);
+    pushClean(result, oldContent.slice(currentPos, change.span.start));
+
+    if (change.newText) {
+      pushClean(result, change.newText);
+    }
 
     currentPos = change.span.start + change.span.length;
   }
 
-  result.push(oldContent.slice(currentPos));
+  pushClean(result, oldContent.slice(currentPos));
 
   return result.join('');
 };

--- a/lib/util/applyTextChanges.ts
+++ b/lib/util/applyTextChanges.ts
@@ -3,23 +3,26 @@ import ts from 'typescript';
 const regex = /\n{2,}$/;
 
 const pushClean = (list: string[], value: string) => {
-  const leadingLineBreakCount = value.match(/^\n+/)?.[0].length || 0;
+  if (value === '') {
+    return;
+  }
 
-  if (leadingLineBreakCount === 0) {
+  const count = value.match(/^\n+/)?.[0].length || 0;
+
+  if (count === 0) {
     list.push(value);
+
     return;
   }
 
   const last = list.pop() || '';
 
-  list.push(
-    `${last}${value.slice(0, leadingLineBreakCount)}`.replace(regex, '\n\n'),
-  );
+  list.push(`${last}${value.slice(0, count)}`.replace(regex, '\n\n'));
 
-  const sliced = value.slice(leadingLineBreakCount);
+  const rest = value.slice(count);
 
-  if (sliced) {
-    list.push(sliced);
+  if (rest) {
+    list.push(rest);
   }
 };
 
@@ -37,19 +40,12 @@ export const applyTextChanges = (
 
   for (const change of sortedChanges) {
     pushClean(result, oldContent.slice(currentPos, change.span.start));
-
-    if (change.newText) {
-      pushClean(result, change.newText);
-    }
+    pushClean(result, change.newText);
 
     currentPos = change.span.start + change.span.length;
   }
 
-  const remaining = oldContent.slice(currentPos);
-
-  if (remaining) {
-    pushClean(result, remaining);
-  }
+  pushClean(result, oldContent.slice(currentPos));
 
   return result
     .join('')

--- a/lib/util/applyTextChanges.ts
+++ b/lib/util/applyTextChanges.ts
@@ -1,7 +1,6 @@
 import ts from 'typescript';
 
-const limitTrailingLineBreak = (value: string, count: number) =>
-  value.replace(new RegExp(`\n{${count},}$`), '\n'.repeat(count));
+const regex = /\n{2,}$/;
 
 const pushClean = (list: string[], value: string) => {
   const leadingLineBreakCount = value.match(/^\n+/)?.[0].length || 0;
@@ -14,10 +13,7 @@ const pushClean = (list: string[], value: string) => {
   const last = list.pop() || '';
 
   list.push(
-    limitTrailingLineBreak(
-      `${last}${value.slice(0, leadingLineBreakCount)}`,
-      2,
-    ),
+    `${last}${value.slice(0, leadingLineBreakCount)}`.replace(regex, '\n\n'),
   );
 
   const sliced = value.slice(leadingLineBreakCount);
@@ -64,7 +60,7 @@ export const applyTextChanges = (
   const lastItem = result.pop();
 
   if (typeof lastItem !== 'undefined') {
-    result.push(limitTrailingLineBreak(lastItem, 1));
+    result.push(lastItem.replace(/\n{1,}$/, '\n'));
   }
 
   return result.join('');

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -46,7 +46,7 @@ describe('removeUnusedExport', () => {
       });
 
       const result = fileService.get('/app/a.ts');
-      assert.equal(result.trim(), `export const a = 'a';`);
+      assert.equal(result, `export const a = 'a';`);
     });
 
     it('should remove export for variable if its not used in some other file', () => {
@@ -61,7 +61,7 @@ describe('removeUnusedExport', () => {
 
       const result = fileService.get('/app/b.ts');
 
-      assert.equal(result.trim(), `const b = 'b';`);
+      assert.equal(result, `const b = 'b';`);
     });
 
     it('should not remove export for variable if it has a comment to ignore', () => {
@@ -81,7 +81,7 @@ describe('removeUnusedExport', () => {
       const result = fileService.get('/app/a.ts');
 
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export const b = 'b';`,
       );
@@ -108,16 +108,13 @@ import c from './c';`,
         targetFile: ['/app/a.ts', '/app/b.ts', '/app/c.ts'],
       });
 
+      assert.equal(fileService.get('/app/a.ts'), `export function a() {}`);
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
-        `export function a() {}`,
-      );
-      assert.equal(
-        fileService.get('/app/b.ts').trim(),
+        fileService.get('/app/b.ts'),
         `export default function b() {}`,
       );
       assert.equal(
-        fileService.get('/app/c.ts').trim(),
+        fileService.get('/app/c.ts'),
         `export default function() {}`,
       );
     });
@@ -134,9 +131,9 @@ import c from './c';`,
         targetFile: ['/app/a.ts', '/app/b.ts', '/app/c.ts'],
       });
 
-      assert.equal(fileService.get('/app/a.ts').trim(), `function a() {}`);
-      assert.equal(fileService.get('/app/b.ts').trim(), `function b() {}`);
-      assert.equal(fileService.get('/app/c.ts').trim(), '');
+      assert.equal(fileService.get('/app/a.ts'), `function a() {}`);
+      assert.equal(fileService.get('/app/b.ts'), `function b() {}`);
+      assert.equal(fileService.get('/app/c.ts'), '');
     });
 
     it('should not remove export if it has a comment to ignore', () => {
@@ -156,7 +153,7 @@ import c from './c';`,
       const result = fileService.get('/app/a.ts');
 
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export function b() {}`,
       );
@@ -183,15 +180,9 @@ import C from './c';`,
         targetFile: ['/app/a.ts', '/app/b.ts', '/app/c.ts'],
       });
 
-      assert.equal(fileService.get('/app/a.ts').trim(), `export class A {}`);
-      assert.equal(
-        fileService.get('/app/b.ts').trim(),
-        `export default class B {}`,
-      );
-      assert.equal(
-        fileService.get('/app/c.ts').trim(),
-        `export default class {}`,
-      );
+      assert.equal(fileService.get('/app/a.ts'), `export class A {}`);
+      assert.equal(fileService.get('/app/b.ts'), `export default class B {}`);
+      assert.equal(fileService.get('/app/c.ts'), `export default class {}`);
     });
 
     it('should remove export for function if its not used in some other file', () => {
@@ -206,9 +197,9 @@ import C from './c';`,
         targetFile: ['/app/a.ts', '/app/b.ts', '/app/c.ts'],
       });
 
-      assert.equal(fileService.get('/app/a.ts').trim(), `class A {}`);
-      assert.equal(fileService.get('/app/b.ts').trim(), `class B {}`);
-      assert.equal(fileService.get('/app/c.ts').trim(), '');
+      assert.equal(fileService.get('/app/a.ts'), `class A {}`);
+      assert.equal(fileService.get('/app/b.ts'), `class B {}`);
+      assert.equal(fileService.get('/app/c.ts'), '');
     });
 
     it('should not remove export if it has a comment to ignore', () => {
@@ -228,7 +219,7 @@ import C from './c';`,
       const result = fileService.get('/app/a.ts');
 
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export class A {}`,
       );
@@ -253,11 +244,11 @@ import B from './b';`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `export interface A { a: 'a' }`,
       );
       assert.equal(
-        fileService.get('/app/b.ts').trim(),
+        fileService.get('/app/b.ts'),
         `export default interface B { b: 'b' }`,
       );
     });
@@ -273,14 +264,8 @@ import B from './b';`,
         targetFile: ['/app/a.ts', '/app/b.ts'],
       });
 
-      assert.equal(
-        fileService.get('/app/a.ts').trim(),
-        `interface A { a: 'a' }`,
-      );
-      assert.equal(
-        fileService.get('/app/b.ts').trim(),
-        `interface B { b: 'b' }`,
-      );
+      assert.equal(fileService.get('/app/a.ts'), `interface A { a: 'a' }`);
+      assert.equal(fileService.get('/app/b.ts'), `interface B { b: 'b' }`);
     });
 
     it('should not remove export if it has a comment to ignore', () => {
@@ -300,7 +285,7 @@ import B from './b';`,
       const result = fileService.get('/app/a.ts');
 
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export interface A { a: 'a' }`,
       );
@@ -320,7 +305,7 @@ import B from './b';`,
       });
 
       const result = fileService.get('/app/a.ts');
-      assert.equal(result.trim(), `export type A = 'a';`);
+      assert.equal(result, `export type A = 'a';`);
     });
 
     it('should remove export for type if its not used in some other file', () => {
@@ -335,7 +320,7 @@ import B from './b';`,
 
       const result = fileService.get('/app/b.ts');
 
-      assert.equal(result.trim(), `type B = 'b';`);
+      assert.equal(result, `type B = 'b';`);
     });
 
     it('should not remove export for type if it has a comment to ignore', () => {
@@ -355,7 +340,7 @@ import B from './b';`,
       const result = fileService.get('/app/a.ts');
 
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export type B = 'b';`,
       );
@@ -390,12 +375,12 @@ export default B;`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `const a = 'a';
   export default a;`,
       );
       assert.equal(
-        fileService.get('/app/b.ts').trim(),
+        fileService.get('/app/b.ts'),
         `type B = 'b';
 export default B;`,
       );
@@ -421,8 +406,8 @@ export default B;`,
         targetFile: ['/app/a.ts', '/app/b.ts'],
       });
 
-      assert.equal(fileService.get('/app/a.ts').trim(), `const a = 'a';`);
-      assert.equal(fileService.get('/app/b.ts').trim(), `type B = 'b';`);
+      assert.equal(fileService.get('/app/a.ts'), `const a = 'a';`);
+      assert.equal(fileService.get('/app/b.ts'), `type B = 'b';`);
     });
 
     it('should not remove default export for an identifier if it has a comment to ignore', () => {
@@ -443,7 +428,7 @@ export default B;`,
 
       const result = fileService.get('/app/a.ts');
       assert.equal(
-        result.trim(),
+        result,
         `const a = 'a';
   // ts-remove-unused-skip
   export default a;`,
@@ -466,7 +451,7 @@ export default B;`,
       });
 
       const result = fileService.get('/app/a.ts');
-      assert.equal(result.trim(), `export default 'a';`);
+      assert.equal(result, `export default 'a';`);
     });
 
     it('should remove default export for a literal if its not used in some other file', () => {
@@ -481,7 +466,7 @@ export default B;`,
       });
 
       const result = fileService.get('/app/a.ts');
-      assert.equal(result.trim(), '');
+      assert.equal(result, '');
     });
 
     it('should not remove default export for a literal if it has a comment to ignore', () => {
@@ -501,7 +486,7 @@ export default B;`,
 
       const result = fileService.get('/app/a.ts');
       assert.equal(
-        result.trim(),
+        result,
         `// ts-remove-unused-skip
   export default 'a';`,
       );
@@ -536,12 +521,12 @@ export { B };`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `const a = 'a';
   export { a };`,
       );
       assert.equal(
-        fileService.get('/app/b.ts').trim(),
+        fileService.get('/app/b.ts'),
         `type B = 'b';
 export { B };`,
       );
@@ -586,17 +571,17 @@ export { d, unused, unused2 };`,
         targetFile: ['/app/a.ts', '/app/b.ts', '/app/c.ts', '/app/d.ts'],
       });
 
-      assert.equal(fileService.get('/app/a.ts').trim(), `const a = 'a';`);
-      assert.equal(fileService.get('/app/b.ts').trim(), `type B = 'b';`);
+      assert.equal(fileService.get('/app/a.ts'), `const a = 'a';`);
+      assert.equal(fileService.get('/app/b.ts'), `type B = 'b';`);
       assert.equal(
-        fileService.get('/app/c.ts').trim(),
+        fileService.get('/app/c.ts'),
         `const c = 'c';
 const remain = 'remain';
 export { remain };`,
       );
 
       assert.equal(
-        fileService.get('/app/d.ts').trim(),
+        fileService.get('/app/d.ts'),
         `const d = 'd';
 const unused = 'unused';
 const unused2 = 'unused2';
@@ -624,7 +609,7 @@ export { d };`,
 
       const result = fileService.get('/app/a.ts');
       assert.equal(
-        result.trim(),
+        result,
         `const a = 'a';
   export { 
     // ts-remove-unused-skip
@@ -649,13 +634,10 @@ export { d };`,
       });
 
       assert.equal(
-        fileService.get('/app/a_reexport.ts').trim(),
+        fileService.get('/app/a_reexport.ts'),
         `export { a } from './a';`,
       );
-      assert.equal(
-        fileService.get('/app/a.ts').trim(),
-        `export const a = 'a';`,
-      );
+      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
 
     it('should remove re-export if its not used in some other file', () => {
@@ -670,7 +652,7 @@ export { d };`,
       });
 
       // removal of /app/a.ts depends on the order of how the target files are passed, so the result of /app/a.ts is not guaranteed
-      assert.equal(fileService.get('/app/a_reexport.ts').trim(), '');
+      assert.equal(fileService.get('/app/a_reexport.ts'), '');
     });
 
     it('should remove specifier if some re-exported specifier is not used in any other file', () => {
@@ -690,7 +672,7 @@ export { d };`,
 
       // todo: is it possible to specify typescript to use single quotes?
       assert.equal(
-        fileService.get('/app/b_reexport.ts').trim(),
+        fileService.get('/app/b_reexport.ts'),
         `export { b1 } from "./b";`,
       );
     });
@@ -719,7 +701,7 @@ export { d };`,
         ],
       });
 
-      assert.equal(fileService.get('/app/a_reexport_1.ts').trim(), '');
+      assert.equal(fileService.get('/app/a_reexport_1.ts'), '');
     });
   });
 
@@ -742,7 +724,7 @@ console.log(b);`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `export const a = 'a';
 const b = 'b';
 console.log(b);`,
@@ -767,7 +749,7 @@ console.log(B);`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `export const a = 'a';
 class B {}
 console.log(B);`,
@@ -792,7 +774,7 @@ const b: B = {};`,
       });
 
       assert.equal(
-        fileService.get('/app/a.ts').trim(),
+        fileService.get('/app/a.ts'),
         `export const a = 'a';
 interface B {}
 const b: B = {};`,
@@ -818,7 +800,7 @@ const b: B = 'b';`,
     });
 
     assert.equal(
-      fileService.get('/app/a.ts').trim(),
+      fileService.get('/app/a.ts'),
       `export const a = 'a';
 type B = 'b';
 const b: B = 'b';`,
@@ -843,7 +825,7 @@ const b: B = {};`,
     });
 
     assert.equal(
-      fileService.get('/app/a.ts').trim(),
+      fileService.get('/app/a.ts'),
       `export const a = 'a';
 interface B {}
 const b: B = {};`,
@@ -1045,7 +1027,7 @@ export const remain = 'remain';`,
     });
 
     assert.equal(
-      fileService.get('/app/a.ts').trim(),
+      fileService.get('/app/a.ts'),
       `export const remain = 'remain';`,
     );
   });

--- a/lib/util/removeUnusedExport.ts
+++ b/lib/util/removeUnusedExport.ts
@@ -364,7 +364,7 @@ const getUpdatedExportDeclaration = (
 
   const printer = ts.createPrinter();
 
-  return result ? printer.printFile(result) : '';
+  return result ? printer.printFile(result).trim() : '';
 };
 
 const getTextChanges = (


### PR DESCRIPTION
this change will make ts-remove-unused handle empty lines in a more sophisticated manner.

- removes leading empty lines from files that were edited
- removes trailing empty lines from files that were edited (limits the line break to max of 1)
- if the edit results in 3 or more consecutive line breaks, it will limit the line break to 2

example: when `const remove` is not used in the following file

```typescript
export const a = 'a';

export const remove = 'remove';

export const a2 = 'a2';
```

## before


```typescript
export const a = 'a';


export const a2 = 'a2';
```

## after

```typescript
export const a = 'a';

export const a2 = 'a2';
```

