### PR TITLE
docs: fix library name in npx example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The CLI will respect the `tsconfig.json` for loading source files.
 Here's an example of using the cli. Make sure to skip your entrypoint file.
 
 ```bash
-npx ts-remove-unused --skip 'src\/main\.ts'
+npx @line/ts-remove-unused --skip 'src\/main\.ts'
 ```
 
 ### Check
@@ -109,7 +109,7 @@ npx ts-remove-unused --skip 'src\/main\.ts'
 Use `--check` to check for unused files and exports without making changes to project files. The command will exit with exit code 1 if there are any unused files or exports discovered.
 
 ```bash
-npx ts-remove-unused --check
+npx @line/ts-remove-unused --check
 ```
 
 ### Use the JavaScript API
@@ -139,7 +139,7 @@ export const hello = 'world';
 The `--skip` option is also available to skip files that match a given regex pattern. Note that you can pass multiple patterns.
 
 ```bash
-npx ts-remove-unused --skip 'src/main\.ts' --skip '/pages/'
+npx @line/ts-remove-unused --skip 'src/main\.ts' --skip '/pages/'
 ```
 
 By default, `.d.ts` files are skipped. If you want to include `.d.ts` files, use the `--include-d-ts` option.


### PR DESCRIPTION
Using with `npx` results in the following error:
<img width="819" alt="Screenshot 2024-09-19 at 08 53 49" src="https://github.com/user-attachments/assets/1458b8f4-0163-4169-bf1f-87b4a0428fc4">
