### PR TITLE
Fix: `import * as foo from './foo'` is not detected as usage when used with reexport

### DIFF
--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -755,6 +755,20 @@ export { d };`,
       assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
 
+    it('should remove declaration that not used in some other file via a whole-reexport', () => {
+      const { languageService, fileService } = setup();
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export const a = 'a';`);
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+      // todo: removing whole re-export is not supported yet
+      // assert.equal(fileService.get('/app/a_reexport.ts'), '');
+      assert.equal(fileService.get('/app/a.ts'), `const a = 'a';`);
+    });
+
     it('should not remove declaration that is used with `import * as name` in some other file via a whole-reexport', () => {
       const { languageService, fileService } = setup();
 

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -791,6 +791,25 @@ a_namespace.a;`,
       );
       assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
+
+    it('should not remove declaration that is used named imported in some other file via a whole-reexport', () => {
+      const { languageService, fileService } = setup();
+
+      fileService.set('/app/main.ts', `import { a } from './a_reexport';`);
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export const a = 'a';`);
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+      assert.equal(
+        fileService.get('/app/a_reexport.ts'),
+        `export * from './a';`,
+      );
+      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
+    });
   });
 
   describe('locally used declaration but not used in any other file', () => {

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -735,6 +735,26 @@ export { d };`,
   });
 
   describe('whole re-export', () => {
+    it('should preserve whole re-export if its used in some other file', () => {
+      const { languageService, fileService } = setup();
+
+      fileService.set('/app/main.ts', `import { a } from './a_reexport';`);
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export const a = 'a';`);
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+
+      assert.equal(
+        fileService.get('/app/a_reexport.ts'),
+        `export * from './a';`,
+      );
+      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
+    });
+
     it('should not remove declaration that is used with `import * as name` in some other file via a whole-reexport', () => {
       const { languageService, fileService } = setup();
 

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -669,29 +669,6 @@ export { d };`,
       assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
 
-    it('should not remove re-export if its used with `import * as` in some other file', () => {
-      const { languageService, fileService } = setup();
-
-      fileService.set(
-        '/app/main.ts',
-        `import * as a_namespace from './a_reexport';
-a_namespace.a;`,
-      );
-      fileService.set('/app/a_reexport.ts', `export * from './a';`);
-      fileService.set('/app/a.ts', `export const a = 'a';`);
-
-      removeUnusedExport({
-        languageService,
-        fileService,
-        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
-      });
-      assert.equal(
-        fileService.get('/app/a_reexport.ts'),
-        `export * from './a';`,
-      );
-      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
-    });
-
     it('should remove re-export if its not used in some other file', () => {
       const { languageService, fileService } = setup();
       fileService.set('/app/a_reexport.ts', `export { a } from './a';`);
@@ -754,6 +731,31 @@ a_namespace.a;`,
       });
 
       assert.equal(fileService.get('/app/a_reexport_1.ts'), '');
+    });
+  });
+
+  describe('whole re-export', () => {
+    it('should not remove declaration that is used with `import * as name` in some other file via a whole-reexport', () => {
+      const { languageService, fileService } = setup();
+
+      fileService.set(
+        '/app/main.ts',
+        `import * as a_namespace from './a_reexport';
+a_namespace.a;`,
+      );
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export const a = 'a';`);
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+      assert.equal(
+        fileService.get('/app/a_reexport.ts'),
+        `export * from './a';`,
+      );
+      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
   });
 

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -735,26 +735,6 @@ export { d };`,
   });
 
   describe('whole re-export', () => {
-    it('should preserve whole re-export if its used in some other file', () => {
-      const { languageService, fileService } = setup();
-
-      fileService.set('/app/main.ts', `import { a } from './a_reexport';`);
-      fileService.set('/app/a_reexport.ts', `export * from './a';`);
-      fileService.set('/app/a.ts', `export const a = 'a';`);
-
-      removeUnusedExport({
-        languageService,
-        fileService,
-        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
-      });
-
-      assert.equal(
-        fileService.get('/app/a_reexport.ts'),
-        `export * from './a';`,
-      );
-      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
-    });
-
     it('should remove declaration that not used in some other file via a whole-reexport', () => {
       const { languageService, fileService } = setup();
       fileService.set('/app/a_reexport.ts', `export * from './a';`);

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -669,6 +669,29 @@ export { d };`,
       assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
 
+    it('should not remove re-export if its used with `import * as` in some other file', () => {
+      const { languageService, fileService } = setup();
+
+      fileService.set(
+        '/app/main.ts',
+        `import * as a_namespace from './a_reexport';
+a_namespace.a;`,
+      );
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export const a = 'a';`);
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+      assert.equal(
+        fileService.get('/app/a_reexport.ts'),
+        `export * from './a';`,
+      );
+      assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
+    });
+
     it('should remove re-export if its not used in some other file', () => {
       const { languageService, fileService } = setup();
       fileService.set('/app/a_reexport.ts', `export { a } from './a';`);

--- a/lib/util/removeUnusedExport.test.ts
+++ b/lib/util/removeUnusedExport.test.ts
@@ -810,6 +810,25 @@ a_namespace.a;`,
       );
       assert.equal(fileService.get('/app/a.ts'), `export const a = 'a';`);
     });
+
+    it('should not remove declaration that is used in default import in some other file via a whole-reexport', () => {
+      const { languageService, fileService } = setup();
+
+      fileService.set('/app/main.ts', `import a from './a_reexport';`);
+      fileService.set('/app/a_reexport.ts', `export * from './a';`);
+      fileService.set('/app/a.ts', `export default 'a';`);
+
+      removeUnusedExport({
+        languageService,
+        fileService,
+        targetFile: ['/app/a.ts', '/app/a_reexport.ts'],
+      });
+      assert.equal(
+        fileService.get('/app/a_reexport.ts'),
+        `export * from './a';`,
+      );
+      assert.equal(fileService.get('/app/a.ts'), `export default 'a';`);
+    });
   });
 
   describe('locally used declaration but not used in any other file', () => {

--- a/lib/util/removeUnusedExport.ts
+++ b/lib/util/removeUnusedExport.ts
@@ -280,12 +280,10 @@ const getUnusedExports = (
         }
 
         const count = references
+          .flatMap((v) => v.references)
           .filter(
-            (v) =>
-              v.definition.fileName !== fileName &&
-              !ancestors.has(v.definition.fileName),
-          )
-          .flatMap((v) => v.references).length;
+            (v) => v.fileName !== fileName && !ancestors.has(v.fileName),
+          ).length;
 
         if (count > 0) {
           isUsed = true;
@@ -297,8 +295,8 @@ const getUnusedExports = (
       }
 
       const count = references
-        .filter((v) => v.definition.fileName !== fileName)
-        .flatMap((v) => v.references).length;
+        .flatMap((v) => v.references)
+        .filter((v) => v.fileName !== fileName).length;
 
       if (count > 0) {
         isUsed = true;


### PR DESCRIPTION
fixes #25