### PR TITLE
perf: share memoization cache between workers

### DIFF
--- a/lib/util/memoize.test.ts
+++ b/lib/util/memoize.test.ts
@@ -7,6 +7,7 @@ describe('memoize', () => {
     const fn = (a: number, b: number) => a + b;
     const memoized = memoize(fn, {
       key: (a, b) => `${a}+${b}`,
+      name: 'fn',
     });
     assert.equal(memoized(1, 2), 3);
   });
@@ -19,6 +20,7 @@ describe('memoize', () => {
     };
     const memoized = memoize(fn, {
       key: (a, b) => `${a}+${b}`,
+      name: 'fn',
     });
 
     assert.equal(memoized(1, 2), 3);

--- a/lib/util/memoize.ts
+++ b/lib/util/memoize.ts
@@ -1,9 +1,19 @@
+import { parentPort } from 'node:worker_threads';
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const memoize = <T extends (...args: any[]) => any>(
   fn: T,
-  { key }: { key: (...args: Parameters<T>) => string },
+  { key, name }: { key: (...args: Parameters<T>) => string; name: string },
 ) => {
   const cache = new Map<string, ReturnType<T>>();
+
+  if (parentPort) {
+    parentPort.on('message', (message) => {
+      if ('broadcast' in message && message.broadcast.name === name) {
+        cache.set(message.broadcast.key, message.broadcast.value);
+      }
+    });
+  }
 
   return (...args: Parameters<T>) => {
     const k = key(...args);
@@ -14,6 +24,15 @@ export const memoize = <T extends (...args: any[]) => any>(
 
     const result = fn(...args) as ReturnType<T>;
     cache.set(k, result);
+    if (parentPort) {
+      parentPort.postMessage({
+        broadcast: {
+          name,
+          key: k,
+          value: result,
+        },
+      });
+    }
     return result;
   };
 };

--- a/lib/util/parseFile.ts
+++ b/lib/util/parseFile.ts
@@ -536,4 +536,5 @@ export const parseFile = memoize(fn, {
       destFiles: Array.from(arg.destFiles).sort(),
       options: arg.options,
     }),
+  name: 'parseFile',
 });


### PR DESCRIPTION
This patch will enable sharing the result of memoized functions between workers. Benchmark shows an 8.8% boost 🚀 

This should also make execution times more consistent because the process times will not change based on how each tasks are allocated to each worker.

before/after:

<img width="912" alt="benchmark" src="https://github.com/user-attachments/assets/ddc0e6af-4fc8-48a8-9fa8-025d71e17b0c">
