### PR TITLE
refactor: add `includeDts` option to `remove()` for clarity

### DIFF
--- a/lib/cli.ts
+++ b/lib/cli.ts
@@ -5,7 +5,6 @@ import { remove } from './remove.js';
 import { createRequire } from 'node:module';
 import { resolve } from 'node:path';
 import { cwd } from 'node:process';
-import { dts } from './util/regex.js';
 const cli = cac('ts-remove-unused');
 
 cli
@@ -34,16 +33,13 @@ cli
           ? [new RegExp(skipArg)]
           : [];
 
-    if (!options['includeD-ts']) {
-      skip.push(dts);
-    }
-
     remove({
       configPath: resolve(options.project || './tsconfig.json'),
       skip,
       mode: options.check ? 'check' : 'write',
       projectRoot: cwd(),
       recursive: !!options.recursive,
+      includeDts: !!options['includeD-ts'],
     });
   });
 

--- a/lib/util/regex.ts
+++ b/lib/util/regex.ts
@@ -1,1 +1,0 @@
-export const dts = /\.d\.ts$/;

--- a/test/fixtures/include_dts/main.ts
+++ b/test/fixtures/include_dts/main.ts
@@ -1,0 +1,5 @@
+import { A } from './types';
+
+const a: A = 'a';
+
+console.log(a);

--- a/test/fixtures/include_dts/types.d.ts
+++ b/test/fixtures/include_dts/types.d.ts
@@ -1,0 +1,3 @@
+export type A = 'a';
+
+export type B = 'b';

--- a/test/include_dts.test.ts
+++ b/test/include_dts.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from 'node:test';
+import { remove } from '../lib/remove.js';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+import assert from 'node:assert/strict';
+import stripAnsi from 'strip-ansi';
+import { stdout } from 'node:process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const LOG = !!process.env.LOG;
+
+describe('project: include_dts', () => {
+  it('should include unused exports from .d.ts files', async () => {
+    let output = '';
+    const logger = {
+      write: (text: string) => {
+        if (LOG) {
+          stdout.write(text);
+        }
+        output += text;
+      },
+      isTTY: false as const,
+    };
+
+    await remove({
+      configPath: resolve(__dirname, 'fixtures/include_dts/tsconfig.json'),
+      skip: [/main\.ts/],
+      projectRoot: resolve(__dirname, 'fixtures/include_dts'),
+      mode: 'check',
+      logger,
+      system: {
+        ...ts.sys,
+        exit: () => {},
+      },
+      includeDts: true,
+    });
+
+    const stripedOutput = stripAnsi(output);
+
+    assert.equal(
+      stripedOutput,
+      `Project has 2 files, skipping 1 file
+export types.d.ts:2:0     'B'
+✖ remove 1 export
+`,
+    );
+  });
+
+  it('should not include unused exports from .d.ts files', async () => {
+    let output = '';
+    const logger = {
+      write: (text: string) => {
+        if (LOG) {
+          stdout.write(text);
+        }
+        output += text;
+      },
+      isTTY: false as const,
+    };
+
+    await remove({
+      configPath: resolve(__dirname, 'fixtures/include_dts/tsconfig.json'),
+      skip: [/main\.ts/],
+      projectRoot: resolve(__dirname, 'fixtures/include_dts'),
+      mode: 'check',
+      logger,
+      system: {
+        ...ts.sys,
+        exit: () => {},
+      },
+      includeDts: false,
+    });
+
+    const stripedOutput = stripAnsi(output);
+
+    assert.equal(
+      stripedOutput,
+      `Project has 2 files, skipping 2 files
+✔ all good!
+`,
+    );
+  });
+});


### PR DESCRIPTION
With this change, `--include-d-ts` will be pass an option to `remove()`, not a shorthand for adding a regex shortcut to make the logic more clear.